### PR TITLE
feat: add SAPUI5 sales dashboard skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# sapui5_codebase
+# SAPUI5 Sales Dashboard
+
+This repository contains a minimal SAPUI5 application. Employees can log in, validate their employee ID via SAP SuccessFactors and view their sales order details from an SAP S/4HANA system.
+
+## Project Structure
+
+- `webapp/index.html` – bootstrap and component container.
+- `webapp/Component.js` – root component initializing models and router.
+- `webapp/manifest.json` – descriptor with data sources for S/4HANA and SuccessFactors.
+- `webapp/view` – XML views for the login page and dashboard.
+- `webapp/controller` – controllers implementing application logic.
+- `webapp/model/models.js` – factory methods for device and OData models.
+- `webapp/css/style.css` – basic styling using CSS.
+
+## Development
+
+Install dependencies and run the application locally:
+
+```bash
+npm install
+npm start
+```
+
+Run a simple build or test:
+
+```bash
+npm run build
+npm test
+```
+
+## Sample Data
+
+For local testing without back-end systems, the application loads sample
+employees and sales orders from JSON files in `webapp/model`. Launch the
+app with `npm start` and use employee ID `1000` or `1001` with the passwords
+defined in `employees.json` to see the dashboard populated with sample
+sales orders.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sapui5-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "ui5 serve",
+    "build": "ui5 build",
+    "test": "echo 'No tests specified'"
+  },
+  "devDependencies": {
+    "@ui5/cli": "^3"
+  }
+}

--- a/ui5.yaml
+++ b/ui5.yaml
@@ -1,0 +1,4 @@
+specVersion: '3.0'
+metadata:
+  name: sapui5-dashboard
+type: application

--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -1,0 +1,30 @@
+sap.ui.define([
+  "sap/ui/core/UIComponent",
+  "sap/ui/model/json/JSONModel",
+  "sap/ui/demo/dashboard/model/models"
+], function (UIComponent, JSONModel, models) {
+  "use strict";
+
+  return UIComponent.extend("sap.ui.demo.dashboard.Component", {
+    metadata: {
+      manifest: "json"
+    },
+
+    init: function () {
+      UIComponent.prototype.init.apply(this, arguments);
+      this.setModel(models.createDeviceModel(), "device");
+      this.setModel(models.createS4Model(), "s4");
+      this.setModel(models.createSFModel(), "sf");
+
+      // sample data models for local testing
+      var oSalesModel = new JSONModel();
+      oSalesModel.loadData(sap.ui.require.toUrl("sap/ui/demo/dashboard/model/salesOrders.json"), null, false);
+      var oEmployeesModel = new JSONModel();
+      oEmployeesModel.loadData(sap.ui.require.toUrl("sap/ui/demo/dashboard/model/employees.json"), null, false);
+      this.setModel(oSalesModel, "sales");
+      this.setModel(oEmployeesModel, "employees");
+
+      this.getRouter().initialize();
+    }
+  });
+});

--- a/webapp/controller/App.controller.js
+++ b/webapp/controller/App.controller.js
@@ -1,0 +1,11 @@
+sap.ui.define([
+  "sap/ui/core/mvc/Controller"
+], function (Controller) {
+  "use strict";
+
+  return Controller.extend("sap.ui.demo.dashboard.controller.App", {
+    onInit: function () {
+      // App controller initialization
+    }
+  });
+});

--- a/webapp/controller/Dashboard.controller.js
+++ b/webapp/controller/Dashboard.controller.js
@@ -1,0 +1,13 @@
+sap.ui.define([
+  "sap/ui/core/mvc/Controller"
+], function (Controller) {
+  "use strict";
+
+  return Controller.extend("sap.ui.demo.dashboard.controller.Dashboard", {
+    onInit: function () {
+      // bind sample sales order data
+      var oSalesModel = this.getOwnerComponent().getModel("sales");
+      this.getView().setModel(oSalesModel);
+    }
+  });
+});

--- a/webapp/controller/Login.controller.js
+++ b/webapp/controller/Login.controller.js
@@ -1,0 +1,30 @@
+sap.ui.define([
+  "sap/ui/core/mvc/Controller",
+  "sap/m/MessageToast"
+], function (Controller, MessageToast) {
+  "use strict";
+
+  return Controller.extend("sap.ui.demo.dashboard.controller.Login", {
+    onLogin: function () {
+      var oView = this.getView();
+      var sEmpId = oView.byId("empId").getValue();
+      var sPassword = oView.byId("password").getValue();
+
+      if (!sEmpId) {
+        MessageToast.show("Please enter Employee ID");
+        return;
+      }
+
+      var aEmployees = this.getOwnerComponent().getModel("employees").getProperty("/Employees");
+      var bValid = aEmployees.some(function (oEmp) {
+        return oEmp.EmployeeID === sEmpId && oEmp.Password === sPassword;
+      });
+
+      if (bValid) {
+        this.getOwnerComponent().getRouter().navTo("dashboard");
+      } else {
+        MessageToast.show("Invalid Employee ID");
+      }
+    }
+  });
+});

--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -1,0 +1,7 @@
+body {
+  background-color: #f5f5f5;
+}
+
+.sapUiSmallMargin {
+  margin: 1rem;
+}

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>SAPUI5 Sales Dashboard</title>
+    <script
+      id="sap-ui-bootstrap"
+      src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
+      data-sap-ui-theme="sap_fiori_3"
+      data-sap-ui-resourceroots='{"sap.ui.demo.dashboard": "./"}'
+      data-sap-ui-onInit="module:sap/ui/core/ComponentSupport"
+      data-sap-ui-compatVersion="edge"
+      data-sap-ui-async="true"
+    ></script>
+    <link rel="stylesheet" type="text/css" href="css/style.css" />
+  </head>
+  <body class="sapUiBody">
+    <div data-sap-ui-component data-name="sap.ui.demo.dashboard" data-id="container" data-settings='{"id" : "dashboard"}'></div>
+  </body>
+</html>

--- a/webapp/manifest.json
+++ b/webapp/manifest.json
@@ -1,0 +1,64 @@
+{
+  "sap.app": {
+    "id": "sap.ui.demo.dashboard",
+    "type": "application",
+    "title": "Sales Dashboard"
+  },
+  "sap.ui5": {
+    "rootView": {
+      "viewName": "sap.ui.demo.dashboard.view.App",
+      "type": "XML",
+      "async": true,
+      "id": "app"
+    },
+    "dependencies": {
+      "minUI5Version": "1.120.0",
+      "libs": {
+        "sap.m": {},
+        "sap.ui.core": {}
+      }
+    },
+    "models": {
+      "": {
+        "dataSource": "s4Service"
+      },
+      "sf": {
+        "dataSource": "sfService"
+      }
+    },
+    "dataSources": {
+      "s4Service": {
+        "uri": "/sap/opu/odata/sap/API_SALES_ORDER_SRV/",
+        "type": "OData",
+        "settings": {
+          "odataVersion": "2.0"
+        }
+      },
+      "sfService": {
+        "uri": "/sfapi/v1/",
+        "type": "OData",
+        "settings": {
+          "odataVersion": "2.0"
+        }
+      }
+    },
+    "routing": {
+      "config": {
+        "routerClass": "sap.m.routing.Router",
+        "viewType": "XML",
+        "viewPath": "sap.ui.demo.dashboard.view",
+        "controlId": "app",
+        "controlAggregation": "pages",
+        "async": true
+      },
+      "routes": [
+        { "pattern": "", "name": "login", "target": "login" },
+        { "pattern": "dashboard", "name": "dashboard", "target": "dashboard" }
+      ],
+      "targets": {
+        "login": { "viewName": "Login" },
+        "dashboard": { "viewName": "Dashboard" }
+      }
+    }
+  }
+}

--- a/webapp/model/employees.json
+++ b/webapp/model/employees.json
@@ -1,0 +1,6 @@
+{
+  "Employees": [
+    {"EmployeeID": "1000", "Password": "pass123"},
+    {"EmployeeID": "1001", "Password": "welcome"}
+  ]
+}

--- a/webapp/model/models.js
+++ b/webapp/model/models.js
@@ -1,0 +1,28 @@
+sap.ui.define([
+  "sap/ui/model/odata/v2/ODataModel",
+  "sap/ui/model/json/JSONModel"
+], function (ODataModel, JSONModel) {
+  "use strict";
+
+  return {
+    createDeviceModel: function () {
+      var oModel = new JSONModel({
+        isTouch: sap.ui.Device.support.touch
+      });
+      oModel.setDefaultBindingMode("OneWay");
+      return oModel;
+    },
+    createS4Model: function () {
+      return new ODataModel({
+        serviceUrl: "/sap/opu/odata/sap/API_SALES_ORDER_SRV/",
+        useBatch: false
+      });
+    },
+    createSFModel: function () {
+      return new ODataModel({
+        serviceUrl: "/sfapi/v1/",
+        useBatch: false
+      });
+    }
+  };
+});

--- a/webapp/model/salesOrders.json
+++ b/webapp/model/salesOrders.json
@@ -1,0 +1,16 @@
+{
+  "A_SalesOrder": [
+    {
+      "SalesOrder": "500000001",
+      "SoldToParty": "Customer A",
+      "TotalNetAmount": "1000",
+      "TransactionCurrency": "USD"
+    },
+    {
+      "SalesOrder": "500000002",
+      "SoldToParty": "Customer B",
+      "TotalNetAmount": "2000",
+      "TransactionCurrency": "USD"
+    }
+  ]
+}

--- a/webapp/view/App.view.xml
+++ b/webapp/view/App.view.xml
@@ -1,0 +1,7 @@
+<mvc:View
+  controllerName="sap.ui.demo.dashboard.controller.App"
+  xmlns:mvc="sap.ui.core.mvc"
+  xmlns="sap.m"
+>
+  <App id="app"/>
+</mvc:View>

--- a/webapp/view/Dashboard.view.xml
+++ b/webapp/view/Dashboard.view.xml
@@ -1,0 +1,26 @@
+<mvc:View
+  controllerName="sap.ui.demo.dashboard.controller.Dashboard"
+  xmlns:mvc="sap.ui.core.mvc"
+  xmlns="sap.m"
+>
+  <Page title="Sales Orders">
+    <content>
+      <Table id="salesTable" items="{path: '/A_SalesOrder'}">
+        <columns>
+          <Column><Text text="Sales Order"/></Column>
+          <Column><Text text="Customer"/></Column>
+          <Column><Text text="Total"/></Column>
+        </columns>
+        <items>
+          <ColumnListItem>
+            <cells>
+              <ObjectIdentifier title="{SalesOrder}"/>
+              <Text text="{SoldToParty}"/>
+              <ObjectNumber number="{TotalNetAmount}" unit="{TransactionCurrency}"/>
+            </cells>
+          </ColumnListItem>
+        </items>
+      </Table>
+    </content>
+  </Page>
+</mvc:View>

--- a/webapp/view/Login.view.xml
+++ b/webapp/view/Login.view.xml
@@ -1,0 +1,15 @@
+<mvc:View
+  controllerName="sap.ui.demo.dashboard.controller.Login"
+  xmlns:mvc="sap.ui.core.mvc"
+  xmlns="sap.m"
+>
+  <Page title="Employee Login">
+    <content>
+      <VBox class="sapUiSmallMargin">
+        <Input id="empId" placeholder="Employee ID"/>
+        <Input id="password" placeholder="Password" type="Password"/>
+        <Button text="Login" press="onLogin" class="sapUiSmallMarginTop"/>
+      </VBox>
+    </content>
+  </Page>
+</mvc:View>


### PR DESCRIPTION
## Summary
- scaffold SAPUI5 application with login and dashboard pages
- connect to S/4HANA and SuccessFactors via OData models
- add local JSON sample data and controllers to allow offline testing
- add basic CSS styling and project configuration

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@ui5%2fcli)*
- `npm test`
- `npm start` *(fails: ui5 not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a314be7bd48321a652b8705f9b7e46